### PR TITLE
Bugfixes:

### DIFF
--- a/etc/lmp/src/pair_chimes.h
+++ b/etc/lmp/src/pair_chimes.h
@@ -27,7 +27,7 @@ PairStyle(chimesFF,PairCHIMES); // PairStyle(key, class)
 
 #include "pair.h"
 
-#include "chimescalc.h"
+#include "chimesFFF.h"
 #include <vector>
 
 

--- a/serial_interface/examples/fortran/Makefile
+++ b/serial_interface/examples/fortran/Makefile
@@ -31,7 +31,7 @@ chimescalc_serial_C.o : $(WRAPPERC_SRC)
 	$(CXX) -c $(WRAPPERC_SRC) -I $(WRAPPERC_LOC) -I $(SERIAL_LOC) -I $(chimescalc_LOC)
 
 WRAPPERF_LOC=$(F_LOC)/../../api
-WRAPPERF_SRC=$(WRAPPERF_LOC)/chimescalc_serial_F.F90
+WRAPPERF_SRC=$(WRAPPERF_LOC)/chimescalc_serial_F.f90
 
 chimescalc_serial_F.o chimescalc_serial.mod : $(WRAPPERF_SRC)
 	$(FCC) -c $(WRAPPERF_SRC) -o chimescalc_serial_F.o

--- a/serial_interface/examples/fortran08/Makefile
+++ b/serial_interface/examples/fortran08/Makefile
@@ -31,8 +31,8 @@ chimescalc_serial_C.o : $(WRAPPERC_SRC)
 	$(CXX) -c $(WRAPPERC_SRC) -I $(WRAPPERC_LOC) -I $(SERIAL_LOC) -I $(CHIMESFF_LOC)
 
 WRAPPERF_LOC=$(F_LOC)/../../api
-WRAPPERF_SRC=$(WRAPPERF_LOC)/chimescalc_serial_F.F90
-WRAPPERF08_SRC=$(WRAPPERF_LOC)/chimescalc_serial_F08.F90
+WRAPPERF_SRC=$(WRAPPERF_LOC)/chimescalc_serial_F.f90
+WRAPPERF08_SRC=$(WRAPPERF_LOC)/chimescalc_serial_F08.f90
 
 chimescalc_serial_F.o wrapper.mod : $(WRAPPERF_SRC)
 	$(FCC) -c $(WRAPPERF_SRC) -o chimescalc_serial_F.o

--- a/serial_interface/tests/run_tests.sh
+++ b/serial_interface/tests/run_tests.sh
@@ -16,35 +16,35 @@ STYLE=${1-"LONG"} # By default,run "LONG" test, but if user runs with "./run_tes
 PREFX=${2-""}     # By default, don't set any special install prefix
 PYTH3=python3.7
 
-FFS[0 ]="published_params.liqC.2b.cubic.txt"                                  ; CFGS[0 ]="liqC.2.5gcc_6000K.OUTCAR_#000.xyz"            ; OPTIONS[0 ]="0"
-FFS[1 ]="published_params.liqC.2+3b.cubic.txt"                                ; CFGS[1 ]="liqC.2.5gcc_6000K.OUTCAR_#000.xyz"            ; OPTIONS[1 ]="0"
-FFS[2 ]="published_params.liqCO.2+3b.cubic.txt"                               ; CFGS[2 ]="CO.2.5gcc_6500K.OUTCAR_#000.xyz"              ; OPTIONS[2 ]="1"
-FFS[3 ]="validated_params.liqCO.2+3b.cubic.txt" ; CFGS[3 ]="CO.2.5gcc_6500K.OUTCAR_#000.relabel.xyz"      ; OPTIONS[3 ]="1"
-FFS[4 ]="published_params.liqCO.2+3b.cubic.txt"         ; CFGS[4 ]="CO.2.5gcc_6500K.OUTCAR_#000.scramble.xyz"     ; OPTIONS[4 ]="1"
-FFS[5 ]="published_params.liqCO.2+3b.cubic.txt"         ; CFGS[5 ]="CO.2.5gcc_6500K.OUTCAR_#000.translate.xyz"    ; OPTIONS[5 ]="1"
-FFS[6 ]="published_params.HN3.2+3+4b.Tersoff.special.offsets.txt"             ; CFGS[6 ]="HN3.2gcc_3000K.OUTCAR_#000.xyz"               ; OPTIONS[6 ]="0"
-FFS[7 ]="validated_params.TiO2.2+3b.Tersoff.txt"                              ; CFGS[7 ]="TiO2.unitcell_arbrot_#000.xyz"                ; OPTIONS[7 ]="0"
-FFS[8 ]="test_params.CHON.txt" ; CFGS[8 ]="CHON.testfile_#000.xyz" ; OPTIONS[8 ]="0"
-FFS[9 ]="published_params.liqCO.2+3b.cubic.txt"                               ; CFGS[9 ]="diam.64_#000.xyz"                             ; OPTIONS[9 ]="1"
-FFS[10]="published_params.liqCO.2+3b.cubic.txt"                               ; CFGS[10]="diam.16_#000.xyz"                             ; OPTIONS[10]="1"
-FFS[11]="published_params.liqCO.2+3b.cubic.txt"                               ; CFGS[11]="diam.8_#000.xyz"                              ; OPTIONS[11]="1"
-FFS[12]="published_params.liqCO.2+3b.cubic.txt"                               ; CFGS[12]="diam.2_#000.xyz"                              ; OPTIONS[12]="1"
-FFS[13]="published_params.CO2400K.2+3+4b.Tersoff.special.offsets.txt" ; CFGS[13]="CO.9GPa_2400K.OUTCAR_#000.xyz" ; OPTIONS[13]="1"
+FFS[0 ]="published_params.liqC.2b.cubic.txt"                          ; CFGS[0 ]="liqC.2.5gcc_6000K.OUTCAR_#000.xyz"		; OPTIONS[0 ]="0"
+FFS[1 ]="published_params.liqC.2+3b.cubic.txt"                        ; CFGS[1 ]="liqC.2.5gcc_6000K.OUTCAR_#000.xyz"		; OPTIONS[1 ]="0"
+FFS[2 ]="published_params.liqCO.2+3b.cubic.txt"                       ; CFGS[2 ]="CO.2.5gcc_6500K.OUTCAR_#000.xyz"		; OPTIONS[2 ]="1"
+FFS[3 ]="validated_params.liqCO.2+3b.cubic.txt"                       ; CFGS[3 ]="CO.2.5gcc_6500K.OUTCAR_#000.relabel.xyz"	; OPTIONS[3 ]="1"
+FFS[4 ]="published_params.liqCO.2+3b.cubic.txt"                       ; CFGS[4 ]="CO.2.5gcc_6500K.OUTCAR_#000.scramble.xyz"	; OPTIONS[4 ]="1"
+FFS[5 ]="published_params.liqCO.2+3b.cubic.txt"                       ; CFGS[5 ]="CO.2.5gcc_6500K.OUTCAR_#000.translate.xyz"	; OPTIONS[5 ]="1"
+FFS[6 ]="published_params.HN3.2+3+4b.Tersoff.special.offsets.txt"     ; CFGS[6 ]="HN3.2gcc_3000K.OUTCAR_#000.xyz"		; OPTIONS[6 ]="0"
+FFS[7 ]="validated_params.TiO2.2+3b.Tersoff.txt"                      ; CFGS[7 ]="TiO2.unitcell_arbrot_#000.xyz"		; OPTIONS[7 ]="0"
+FFS[8 ]="test_params.CHON.txt"                                        ; CFGS[8 ]="CHON.testfile_#000.xyz"	                ; OPTIONS[8 ]="0"
+FFS[9 ]="published_params.liqCO.2+3b.cubic.txt"                       ; CFGS[9 ]="diam.64_#000.xyz"				; OPTIONS[9 ]="1"
+FFS[10]="published_params.liqCO.2+3b.cubic.txt"                       ; CFGS[10]="diam.16_#000.xyz"				; OPTIONS[10]="1"
+FFS[11]="published_params.liqCO.2+3b.cubic.txt"                       ; CFGS[11]="diam.8_#000.xyz"				; OPTIONS[11]="1"
+FFS[12]="published_params.liqCO.2+3b.cubic.txt"                       ; CFGS[12]="diam.2_#000.xyz"				; OPTIONS[12]="1"
+FFS[13]="published_params.CO2400K.2+3+4b.Tersoff.special.offsets.txt" ; CFGS[13]="CO.9GPa_2400K.OUTCAR_#000.xyz"                ; OPTIONS[13]="1"
 
 API_LIST="0 1 2 3 4"
 NO_TESTS=${#FFS[@]}
 LOC=`pwd`
 
-API[0]="cpp"    ;   EXE[0]="CPP-interface"                    ;   XTRA[0]="" #"2"
-API[1]="c"      ;   EXE[1]="C_wrapper-serial_interface"       ;   XTRA[1]="" #"2"
-API[2]="fortran";   EXE[2]="fortran_wrapper-serial_interface" ;   XTRA[2]="" #"2"
-API[3]="python" ;   EXE[3]="main.py"                          ;   XTRA[3]="" #"2 1"
+API[0]="cpp"      ; EXE[0]="CPP-interface"		        ; XTRA[0]="" #"2"
+API[1]="c"        ; EXE[1]="C_wrapper-serial_interface"         ; XTRA[1]="" #"2"
+API[2]="fortran"  ; EXE[2]="fortran_wrapper-serial_interface"   ; XTRA[2]="" #"2"
+API[3]="python"   ; EXE[3]="main.py"			        ; XTRA[3]="" #"2 1"
 API[4]="fortran08"; EXE[4]="fortran08_wrapper-serial_interface" ; XTRA[4]="" #"0"
 
 echo "Running $STYLE tests"
 date
 
-for compile in Makefile # CMAKE
+for compile in MAKEFILE # CMAKE
 do
 	echo "Testing compilation type: $compile"
 
@@ -154,7 +154,7 @@ done
 for i in $API_LIST # Cycle through APIs
 do
 	cd ../examples/${API[$i]}
-	make clean
+	make clean-all
 	rm -f *.so *.a
 	cd ../../tests
 done


### PR DESCRIPTION
- LAMMPS linking header file name not properly updated since file name changes
- Fortran file extension casing incorrect in Makefiles
- run_tests.sh compile type casing incorrect, make clean missing "-all"

Note: test suite only run for 1st FF for each API
[run_tests-hotfix2.log](https://github.com/RKLindsey/chimes_calculator/files/7730064/run_tests-hotfix2.log)


## Pull request template

- N/A: Requested `develop` as target branch
- [x] Attached test suite log file
- [x] Alerted reviewers if edits impact CMake or Makefile files
